### PR TITLE
Add Casper Client SDKs

### DIFF
--- a/ecosystem/java_sdk/data.md
+++ b/ecosystem/java_sdk/data.md
@@ -1,0 +1,28 @@
+---
+Name: "Java Casper Client SDK",
+Website: "https://github.com/casper-network/casper-java-sdk/",
+Twitter: "",
+Architecture: "Infrastructure",
+Segment: "SDK",
+Category: "",
+Application-Category: "",
+Tags: "SDK",
+Contact: "",
+Project-Status: "Not Live - In Development",
+Contract-Hashes-Main: "",
+Contract-Hashes-Test: "",
+---
+<!--lang:en--> 
+Java library for interacting with a CSPR node.
+This project implements the SDK to interact with a Casper Node. It wraps the Json-RPC requests and maps the results to Java objects.
+<!--lang:es--] 
+
+<!--lang:de--] 
+
+<!--lang:fr--] 
+
+<!--lang:pl--] 
+
+<!--lang:uk--] 
+
+[!--lang:*-->  

--- a/ecosystem/js_ts_sdk/data.md
+++ b/ecosystem/js_ts_sdk/data.md
@@ -1,0 +1,27 @@
+---
+Name: "TypeScript Casper Client SDK",
+Website: "https://github.com/casper-ecosystem/casper-js-sdk",
+Twitter: "",
+Architecture: "Infrastructure",
+Segment: "SDK",
+Category: "",
+Application-Category: "",
+Tags: "SDK",
+Contact: "jan@hfmn.pl",
+Project-Status: "Live",
+Contract-Hashes-Main: "",
+Contract-Hashes-Test: "",
+---
+<!--lang:en--> 
+
+<!--lang:es--] 
+
+<!--lang:de--] 
+
+<!--lang:fr--] 
+
+<!--lang:pl--] 
+
+<!--lang:uk--] 
+
+[!--lang:*-->  

--- a/ecosystem/python_sdk/data.md
+++ b/ecosystem/python_sdk/data.md
@@ -1,0 +1,28 @@
+---
+Name: "Python Casper Client SDK",
+Website: "https://github.com/casper-network/casper-python-sdk/",
+Twitter: "@asladeofgreen",
+Architecture: "Infrastructure",
+Segment: "SDK",
+Category: "",
+Application-Category: "",
+Tags: "SDK",
+Contact: "mark@casper.network",
+Project-Status: "Live",
+Contract-Hashes-Main: "",
+Contract-Hashes-Test: "",
+---
+<!--lang:en--> 
+Python 3.9+ library for interacting with a CSPR node. 
+The Python client is published as pycspr: PYthon CaSPeR. It's goal is to streamline client side experience of interacting with a Casper node.
+<!--lang:es--] 
+
+<!--lang:de--] 
+
+<!--lang:fr--] 
+
+<!--lang:pl--] 
+
+<!--lang:uk--] 
+
+[!--lang:*-->  


### PR DESCRIPTION
Resolves #19 

Add Casper Client SDKs to the Project List

This PR adds following Casper Client SDKs;
- [TypeScript Casper Client SDK](https://github.com/casper-ecosystem/casper-js-sdk)
- [Java Casper Client SDK](https://github.com/casper-network/casper-java-sdk)
- [Python Casper Client SDK](https://github.com/casper-network/casper-python-sdk/)