### PR TITLE
Fix nitro and changenow repo urls

### DIFF
--- a/repositories/nitro_by_router_protocol/data.md
+++ b/repositories/nitro_by_router_protocol/data.md
@@ -1,6 +1,6 @@
 --- 
 Name: "Nitro (by Router Protocol)", 
-Website: "https://github.com/router-protocol", 
+Website: "https://github.com/router-protocol/router-chain-docs", 
 Projects: "Nitro (by Router Protocol)",
 --- 
 <!--lang:en--> 

--- a/repositories/nowpayments/data.md
+++ b/repositories/nowpayments/data.md
@@ -1,6 +1,6 @@
 --- 
 Name: "NOWPayments", 
-Website: "https://github.com/NowPaymentsIO", 
+Website: "https://github.com/NowPaymentsIO/nowpayments-api-js", 
 Projects: "ChangeNOW",
 --- 
 <!--lang:en--> 


### PR DESCRIPTION
Issue Background:
The issue with the Nitro and ChangeNow Repository entries is that they were created using IFF.

In that, the users gave their GitHub Org URL as opposed to a specific repository URL. This lead to the backend failing with 404 when it tried to query the GitHub stats like no. of stars, forks etc.

Therefore, this PR is created to fix these issues, by updating the GH links with one of their valid links (e.g. docs repo).

Changelog:
```bash
        modified:   repositories/nitro_by_router_protocol/data.md
        modified:   repositories/nowpayments/data.md
```